### PR TITLE
remove default foreground option from pidfile context

### DIFF
--- a/wazo_purge_db/cli.py
+++ b/wazo_purge_db/cli.py
@@ -47,7 +47,7 @@ def main():
 
     xivo_dao.init_db_from_config(config)
 
-    with pidfile_context(config['pid_file'], foreground=True):
+    with pidfile_context(config['pid_file']):
         if 'archives' in config.get('enabled_plugins', {}):
             _load_plugins(config)
         _purge_tables(config)


### PR DESCRIPTION
reason: default is now to True and will be removed since no one use it