### PR TITLE
fix race condition with integration tests 

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -10,6 +10,8 @@ test-image:
 test:
 	docker-compose run sync
 	docker-compose run purgedb
+	# Let time to container to stop
+	sleep 2
 	docker-compose kill
 	docker-compose rm -f
 


### PR DESCRIPTION
why: with docker-compose v2, the command is returned before that docker
is really exiting. So the next command (kill) will evaluate containers
that need to be stopped and will try to stop a container that is
actually in the stopping process ...