### PR TITLE
use docker compose without hyphen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ integration tests faster with:
 
 ```
 cd integration_tests
-docker-compose run sync
-docker-compose run purgedb  # repeat to run the tests against new code
+docker compose run sync
+docker compose run purgedb  # repeat to run the tests against new code
 ```

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -8,11 +8,11 @@ test-image:
 	docker build --no-cache -t wazo-purge-db-test -f Dockerfile ..
 
 test:
-	docker-compose run sync
-	docker-compose run purgedb
+	docker compose run sync
+	docker compose run purgedb
 	# Let time to container to stop
 	sleep 2
-	docker-compose kill
-	docker-compose rm -f
+	docker compose kill
+	docker compose rm -f
 
 .PHONY: test test-image test-setup egg-info


### PR DESCRIPTION
why: it's now the recommended way to use docker compose